### PR TITLE
Add select UI element for override default language (#9)

### DIFF
--- a/app/page/blockeditor.html
+++ b/app/page/blockeditor.html
@@ -127,75 +127,272 @@
                         </div>
                         <div id="modalFormScripts"></div>
         
+                        <!-- Settings -->
                         <div id="Settings" class="px-3 d-none" style="border-top: 1px solid grey">
                             <div class="px-2 mt-4">
+                                <!-- Page Title -->
                                 <div class="card mb-3">
                                     <div class="card-header">Page Title</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <input type="text" class="form-control" id="setting-page-title" />
                                     </div>
                                 </div>
+                                <!-- Page Description -->
                                 <div class="card mb-3">
                                     <div class="card-header">Page Description</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <textarea class="form-control" id="setting-page-description"></textarea>
                                     </div>
                                 </div>
+                                <!-- Page Language Override -->
+                                <select name="lang" id="lang">
+                                    <option value="default">Use Site Default</option>
+                                    <option value="ab">Abkhazian</option>
+                                    <option value="aa">Afar</option>
+                                    <option value="af">Afrikaans</option>
+                                    <option value="ak">Akan</option>
+                                    <option value="sq">Albanian</option>
+                                    <option value="am">Amharic</option>
+                                    <option value="ar">Arabic</option>
+                                    <option value="an">Aragonese</option>
+                                    <option value="hy">Armenian</option>
+                                    <option value="as">Assamese</option>
+                                    <option value="av">Avaric</option>
+                                    <option value="ae">Avestan</option>
+                                    <option value="ay">Aymara</option>
+                                    <option value="az">Azerbaijani</option>
+                                    <option value="bm">Bambara</option>
+                                    <option value="ba">Bashkir</option>
+                                    <option value="eu">Basque</option>
+                                    <option value="be">Belarusian</option>
+                                    <option value="bn">Bengali (Bangla)</option>
+                                    <option value="bh">Bihari</option>
+                                    <option value="bi">Bislama</option>
+                                    <option value="bs">Bosnian</option>
+                                    <option value="br">Breton</option>
+                                    <option value="bg">Bulgarian</option>
+                                    <option value="my">Burmese</option>
+                                    <option value="ca">Catalan</option>
+                                    <option value="ch">Chamorro</option>
+                                    <option value="ce">Chechen</option>
+                                    <option value="ny">Chichewa, Chewa, Nyanja</option>
+                                    <option value="zh">Chinese</option>
+                                    <option value="zh-Hans">Chinese (Simplified)</option>
+                                    <option value="zh-Hant">Chinese (Traditional)</option>
+                                    <option value="cv">Chuvash</option>
+                                    <option value="kw">Cornish</option>
+                                    <option value="co">Corsican</option>
+                                    <option value="cr">Cree</option>
+                                    <option value="hr">Croatian</option>
+                                    <option value="cs">Czech</option>
+                                    <option value="da">Danish</option>
+                                    <option value="dv">Divehi, Dhivehi, Maldivian</option>
+                                    <option value="nl">Dutch</option>
+                                    <option value="dz">Dzongkha</option>
+                                    <option value="en">English</option>
+                                    <option value="eo">Esperanto</option>
+                                    <option value="et">Estonian</option>
+                                    <option value="ee">Ewe</option>
+                                    <option value="fo">Faroese</option>
+                                    <option value="fj">Fijian</option>
+                                    <option value="fi">Finnish</option>
+                                    <option value="fr">French</option>
+                                    <option value="ff">Fula, Fulah, Pulaar, Pular</option>
+                                    <option value="gl">Galician</option>
+                                    <option value="gd">Gaelic (Scottish)</option>
+                                    <option value="gv">Gaelic (Manx)</option>
+                                    <option value="ka">Georgian</option>
+                                    <option value="de">German</option>
+                                    <option value="el">Greek</option>
+                                    <option value="kl">Greenlandic</option>
+                                    <option value="gn">Guarani</option>
+                                    <option value="gu">Gujarati</option>
+                                    <option value="ht">Haitian Creole</option>
+                                    <option value="ha">Hausa</option>
+                                    <option value="he">Hebrew</option>
+                                    <option value="hz">Herero</option>
+                                    <option value="hi">Hindi</option>
+                                    <option value="ho">Hiri Motu</option>
+                                    <option value="hu">Hungarian</option>
+                                    <option value="is">Icelandic</option>
+                                    <option value="io">Ido</option>
+                                    <option value="ig">Igbo</option>
+                                    <option value="id">Indonesian</option>
+                                    <option value="in">Indonesian</option>
+                                    <option value="ia">Interlingua</option>
+                                    <option value="ie">Interlingue</option>
+                                    <option value="iu">Inuktitut</option>
+                                    <option value="ik">Inupiak</option>
+                                    <option value="ga">Irish</option>
+                                    <option value="it">Italian</option>
+                                    <option value="ja">Japanese</option>
+                                    <option value="jv">Javanese</option>
+                                    <option value="kn">Kannada</option>
+                                    <option value="kr">Kanuri</option>
+                                    <option value="ks">Kashmiri</option>
+                                    <option value="kk">Kazakh</option>
+                                    <option value="km">Khmer</option>
+                                    <option value="ki">Kikuyu</option>
+                                    <option value="rw">Kinyarwanda (Rwanda)</option>
+                                    <option value="rn">Kirundi</option>
+                                    <option value="ky">Kyrgyz</option>
+                                    <option value="kv">Komi</option>
+                                    <option value="kg">Kongo</option>
+                                    <option value="ko">Korean</option>
+                                    <option value="ku">Kurdish</option>
+                                    <option value="kj">Kwanyama</option>
+                                    <option value="lo">Lao</option>
+                                    <option value="la">Latin</option>
+                                    <option value="lv">Latvian (Lettish)</option>
+                                    <option value="li">Limburgish (Limburger)</option>
+                                    <option value="ln">Lingala</option>
+                                    <option value="lt">Lithuanian</option>
+                                    <option value="lu">Luga-Katanga</option>
+                                    <option value="lg">Luganda, Ganda</option>
+                                    <option value="lb">Luxembourgish</option>
+                                    <option value="mk">Macedonian</option>
+                                    <option value="mg">Malagasy</option>
+                                    <option value="ms">Malay</option>
+                                    <option value="ml">Malayalam</option>
+                                    <option value="mt">Maltese</option>
+                                    <option value="mi">Maori</option>
+                                    <option value="mr">Marathi</option>
+                                    <option value="mh">Marshallese</option>
+                                    <option value="mo">Moldavian</option>
+                                    <option value="mn">Mongolian</option>
+                                    <option value="na">Nauru</option>
+                                    <option value="nv">Navajo</option>
+                                    <option value="ng">Ndonga</option>
+                                    <option value="nd">Northern Ndebele</option>
+                                    <option value="ne">Nepali</option>
+                                    <option value="no">Norwegian</option>
+                                    <option value="nb">Norwegian bokmål</option>
+                                    <option value="nn">Norwegian nynorsk</option>
+                                    <option value="ii">Nuosu</option>
+                                    <option value="oc">Occitan</option>
+                                    <option value="oj">Ojibwe</option>
+                                    <option value="cu">Old Church Slavonic, Old Bulgarian</option>
+                                    <option value="or">Oriya</option>
+                                    <option value="om">Oromo (Afaan Oromo)</option>
+                                    <option value="os">Ossetian</option>
+                                    <option value="pi">Pāli</option>
+                                    <option value="ps">Pashto, Pushto</option>
+                                    <option value="fa">Persian (Farsi)</option>
+                                    <option value="pl">Polish</option>
+                                    <option value="pt">Portuguese</option>
+                                    <option value="pa">Punjabi (Eastern)</option>
+                                    <option value="qu">Quechua</option>
+                                    <option value="rm">Romansh</option>
+                                    <option value="ro">Romanian</option>
+                                    <option value="ru">Russian</option>
+                                    <option value="se">Sami</option>
+                                    <option value="sm">Samoan</option>
+                                    <option value="sg">Sango</option>
+                                    <option value="sa">Sanskrit</option>
+                                    <option value="sr">Serbian</option>
+                                    <option value="sh">Serbo-Croatian</option>
+                                    <option value="st">Sesotho</option>
+                                    <option value="tn">Setswana</option>
+                                    <option value="sn">Shona</option>
+                                    <option value="ii">Sichuan Yi</option>
+                                    <option value="sd">Sindhi</option>
+                                    <option value="si">Sinhalese</option>
+                                    <option value="ss">Siswati</option>
+                                    <option value="sk">Slovak</option>
+                                    <option value="sl">Slovenian</option>
+                                    <option value="so">Somali</option>
+                                    <option value="nr">Southern Ndebele</option>
+                                    <option value="es">Spanish</option>
+                                    <option value="su">Sundanese</option>
+                                    <option value="sw">Swahili (Kiswahili)</option>
+                                    <option value="ss">Swati</option>
+                                    <option value="sv">Swedish</option>
+                                    <option value="tl">Tagalog</option>
+                                    <option value="ty">Tahitian</option>
+                                    <option value="tg">Tajik</option>
+                                    <option value="ta">Tamil</option>
+                                    <option value="tt">Tatar</option>
+                                    <option value="te">Telugu</option>
+                                    <option value="th">Thai</option>
+                                    <option value="bo">Tibetan</option>
+                                    <option value="ti">Tigrinya</option>
+                                    <option value="to">Tonga</option>
+                                    <option value="ts">Tsonga</option>
+                                    <option value="tr">Turkish</option>
+                                    <option value="tk">Turkmen</option>
+                                    <option value="tw">Twi</option>
+                                    <option value="ug">Uyghur</option>
+                                    <option value="uk">Ukrainian</option>
+                                    <option value="ur">Urdu</option>
+                                    <option value="uz">Uzbek</option>
+                                    <option value="ve">Venda</option>
+                                    <option value="vi">Vietnamese</option>
+                                    <option value="vo">Volapük</option>
+                                    <option value="wa">Wallon</option>
+                                    <option value="cy">Welsh</option>
+                                    <option value="wo">Wolof</option>
+                                    <option value="fy">Western Frisian</option>
+                                    <option value="xh">Xhosa</option>
+                                    <option value="yi">Yiddish</option>
+                                    <option value="ji">Yiddish</option>
+                                    <option value="yo">Yoruba</option>
+                                    <option value="za">Zhuang, Chuang</option>
+                                    <option value="zu">Zulu</option>
+                                </select>
+                                <!-- Include in Sitemap? -->
                                 <div class="card mb-3 d-none" id="sitemap-option-wrapper">
                                     <div class="card-header">Include in Sitemap</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-sitemap-include">
                                             <option value="0">No</option>
                                             <option value="1">Yes</option>
                                         </select>
                                     </div>
                                 </div>
+                                <!-- Obfuscate JavaScript -->
                                 <div class="card mb-3" id="obfuscatejs-option-wrapper">
-                                    <div class="card-header">Obfuscate Javascript</div>
+                                    <div class="card-header">Obfuscate JavaScript</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-obfuscatejs">
                                             <option value="0">No</option>
                                             <option value="1">Yes</option>
                                         </select>
                                     </div>
                                 </div>
+                                <!-- Wrap in Container Div (container container-flex) -->
                                 <div class="card mb-3">
                                     <div class="card-header">Wrap HTML in Container Div</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-use_container">
                                             <option value="1">Yes</option>
                                             <option value="0">No</option>
                                         </select>
                                     </div>
                                 </div>
+                                <!-- Main Navigation -->
                                 <div class="card mb-3">
                                     <div class="card-header">Main Navigation</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-main-navigation"><option selected value="0">None</option></select>
                                     </div>
                                 </div>
+                                <!-- Side Navigation -->
                                 <div class="card mb-3">
                                     <div class="card-header">Side Navigation</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-side-navigation"><option selected value="0">None</option></select>
                                     </div>
                                 </div>
+                                <!-- Footer -->
                                 <div class="card mb-3">
                                     <div class="card-header">Footer</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-footer"><option selected value="0">None</option></select>
                                     </div>
                                 </div>
                             </div>
                         </div>
+                        <!-- End Settings -->
                     </div>
                 </div>
             </div>

--- a/app/page/index.html
+++ b/app/page/index.html
@@ -141,88 +141,285 @@
                         </div>
                         <div id="modalFormComponent"></div>
 
+                        <!-- Settings -->
                         <div id="Settings" class="px-3 d-none" style="border-top: 1px solid grey">
                             <div class="px-2 mt-4">
+                                <!-- Page Title -->
                                 <div class="card mb-3">
                                     <div class="card-header">Page Title</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <input type="text" class="form-control" id="setting-page-title" />
                                     </div>
                                 </div>
+                                <!-- Page Description -->
                                 <div class="card mb-3">
                                     <div class="card-header">Page Description</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <textarea class="form-control" id="setting-page-description"></textarea>
                                     </div>
                                 </div>
+                                <!-- Page Language Override -->
+                                <select name="lang" id="lang">
+                                    <option value="default">Use Site Default</option>
+                                    <option value="ab">Abkhazian</option>
+                                    <option value="aa">Afar</option>
+                                    <option value="af">Afrikaans</option>
+                                    <option value="ak">Akan</option>
+                                    <option value="sq">Albanian</option>
+                                    <option value="am">Amharic</option>
+                                    <option value="ar">Arabic</option>
+                                    <option value="an">Aragonese</option>
+                                    <option value="hy">Armenian</option>
+                                    <option value="as">Assamese</option>
+                                    <option value="av">Avaric</option>
+                                    <option value="ae">Avestan</option>
+                                    <option value="ay">Aymara</option>
+                                    <option value="az">Azerbaijani</option>
+                                    <option value="bm">Bambara</option>
+                                    <option value="ba">Bashkir</option>
+                                    <option value="eu">Basque</option>
+                                    <option value="be">Belarusian</option>
+                                    <option value="bn">Bengali (Bangla)</option>
+                                    <option value="bh">Bihari</option>
+                                    <option value="bi">Bislama</option>
+                                    <option value="bs">Bosnian</option>
+                                    <option value="br">Breton</option>
+                                    <option value="bg">Bulgarian</option>
+                                    <option value="my">Burmese</option>
+                                    <option value="ca">Catalan</option>
+                                    <option value="ch">Chamorro</option>
+                                    <option value="ce">Chechen</option>
+                                    <option value="ny">Chichewa, Chewa, Nyanja</option>
+                                    <option value="zh">Chinese</option>
+                                    <option value="zh-Hans">Chinese (Simplified)</option>
+                                    <option value="zh-Hant">Chinese (Traditional)</option>
+                                    <option value="cv">Chuvash</option>
+                                    <option value="kw">Cornish</option>
+                                    <option value="co">Corsican</option>
+                                    <option value="cr">Cree</option>
+                                    <option value="hr">Croatian</option>
+                                    <option value="cs">Czech</option>
+                                    <option value="da">Danish</option>
+                                    <option value="dv">Divehi, Dhivehi, Maldivian</option>
+                                    <option value="nl">Dutch</option>
+                                    <option value="dz">Dzongkha</option>
+                                    <option value="en">English</option>
+                                    <option value="eo">Esperanto</option>
+                                    <option value="et">Estonian</option>
+                                    <option value="ee">Ewe</option>
+                                    <option value="fo">Faroese</option>
+                                    <option value="fj">Fijian</option>
+                                    <option value="fi">Finnish</option>
+                                    <option value="fr">French</option>
+                                    <option value="ff">Fula, Fulah, Pulaar, Pular</option>
+                                    <option value="gl">Galician</option>
+                                    <option value="gd">Gaelic (Scottish)</option>
+                                    <option value="gv">Gaelic (Manx)</option>
+                                    <option value="ka">Georgian</option>
+                                    <option value="de">German</option>
+                                    <option value="el">Greek</option>
+                                    <option value="kl">Greenlandic</option>
+                                    <option value="gn">Guarani</option>
+                                    <option value="gu">Gujarati</option>
+                                    <option value="ht">Haitian Creole</option>
+                                    <option value="ha">Hausa</option>
+                                    <option value="he">Hebrew</option>
+                                    <option value="hz">Herero</option>
+                                    <option value="hi">Hindi</option>
+                                    <option value="ho">Hiri Motu</option>
+                                    <option value="hu">Hungarian</option>
+                                    <option value="is">Icelandic</option>
+                                    <option value="io">Ido</option>
+                                    <option value="ig">Igbo</option>
+                                    <option value="id">Indonesian</option>
+                                    <option value="in">Indonesian</option>
+                                    <option value="ia">Interlingua</option>
+                                    <option value="ie">Interlingue</option>
+                                    <option value="iu">Inuktitut</option>
+                                    <option value="ik">Inupiak</option>
+                                    <option value="ga">Irish</option>
+                                    <option value="it">Italian</option>
+                                    <option value="ja">Japanese</option>
+                                    <option value="jv">Javanese</option>
+                                    <option value="kn">Kannada</option>
+                                    <option value="kr">Kanuri</option>
+                                    <option value="ks">Kashmiri</option>
+                                    <option value="kk">Kazakh</option>
+                                    <option value="km">Khmer</option>
+                                    <option value="ki">Kikuyu</option>
+                                    <option value="rw">Kinyarwanda (Rwanda)</option>
+                                    <option value="rn">Kirundi</option>
+                                    <option value="ky">Kyrgyz</option>
+                                    <option value="kv">Komi</option>
+                                    <option value="kg">Kongo</option>
+                                    <option value="ko">Korean</option>
+                                    <option value="ku">Kurdish</option>
+                                    <option value="kj">Kwanyama</option>
+                                    <option value="lo">Lao</option>
+                                    <option value="la">Latin</option>
+                                    <option value="lv">Latvian (Lettish)</option>
+                                    <option value="li">Limburgish (Limburger)</option>
+                                    <option value="ln">Lingala</option>
+                                    <option value="lt">Lithuanian</option>
+                                    <option value="lu">Luga-Katanga</option>
+                                    <option value="lg">Luganda, Ganda</option>
+                                    <option value="lb">Luxembourgish</option>
+                                    <option value="mk">Macedonian</option>
+                                    <option value="mg">Malagasy</option>
+                                    <option value="ms">Malay</option>
+                                    <option value="ml">Malayalam</option>
+                                    <option value="mt">Maltese</option>
+                                    <option value="mi">Maori</option>
+                                    <option value="mr">Marathi</option>
+                                    <option value="mh">Marshallese</option>
+                                    <option value="mo">Moldavian</option>
+                                    <option value="mn">Mongolian</option>
+                                    <option value="na">Nauru</option>
+                                    <option value="nv">Navajo</option>
+                                    <option value="ng">Ndonga</option>
+                                    <option value="nd">Northern Ndebele</option>
+                                    <option value="ne">Nepali</option>
+                                    <option value="no">Norwegian</option>
+                                    <option value="nb">Norwegian bokmål</option>
+                                    <option value="nn">Norwegian nynorsk</option>
+                                    <option value="ii">Nuosu</option>
+                                    <option value="oc">Occitan</option>
+                                    <option value="oj">Ojibwe</option>
+                                    <option value="cu">Old Church Slavonic, Old Bulgarian</option>
+                                    <option value="or">Oriya</option>
+                                    <option value="om">Oromo (Afaan Oromo)</option>
+                                    <option value="os">Ossetian</option>
+                                    <option value="pi">Pāli</option>
+                                    <option value="ps">Pashto, Pushto</option>
+                                    <option value="fa">Persian (Farsi)</option>
+                                    <option value="pl">Polish</option>
+                                    <option value="pt">Portuguese</option>
+                                    <option value="pa">Punjabi (Eastern)</option>
+                                    <option value="qu">Quechua</option>
+                                    <option value="rm">Romansh</option>
+                                    <option value="ro">Romanian</option>
+                                    <option value="ru">Russian</option>
+                                    <option value="se">Sami</option>
+                                    <option value="sm">Samoan</option>
+                                    <option value="sg">Sango</option>
+                                    <option value="sa">Sanskrit</option>
+                                    <option value="sr">Serbian</option>
+                                    <option value="sh">Serbo-Croatian</option>
+                                    <option value="st">Sesotho</option>
+                                    <option value="tn">Setswana</option>
+                                    <option value="sn">Shona</option>
+                                    <option value="ii">Sichuan Yi</option>
+                                    <option value="sd">Sindhi</option>
+                                    <option value="si">Sinhalese</option>
+                                    <option value="ss">Siswati</option>
+                                    <option value="sk">Slovak</option>
+                                    <option value="sl">Slovenian</option>
+                                    <option value="so">Somali</option>
+                                    <option value="nr">Southern Ndebele</option>
+                                    <option value="es">Spanish</option>
+                                    <option value="su">Sundanese</option>
+                                    <option value="sw">Swahili (Kiswahili)</option>
+                                    <option value="ss">Swati</option>
+                                    <option value="sv">Swedish</option>
+                                    <option value="tl">Tagalog</option>
+                                    <option value="ty">Tahitian</option>
+                                    <option value="tg">Tajik</option>
+                                    <option value="ta">Tamil</option>
+                                    <option value="tt">Tatar</option>
+                                    <option value="te">Telugu</option>
+                                    <option value="th">Thai</option>
+                                    <option value="bo">Tibetan</option>
+                                    <option value="ti">Tigrinya</option>
+                                    <option value="to">Tonga</option>
+                                    <option value="ts">Tsonga</option>
+                                    <option value="tr">Turkish</option>
+                                    <option value="tk">Turkmen</option>
+                                    <option value="tw">Twi</option>
+                                    <option value="ug">Uyghur</option>
+                                    <option value="uk">Ukrainian</option>
+                                    <option value="ur">Urdu</option>
+                                    <option value="uz">Uzbek</option>
+                                    <option value="ve">Venda</option>
+                                    <option value="vi">Vietnamese</option>
+                                    <option value="vo">Volapük</option>
+                                    <option value="wa">Wallon</option>
+                                    <option value="cy">Welsh</option>
+                                    <option value="wo">Wolof</option>
+                                    <option value="fy">Western Frisian</option>
+                                    <option value="xh">Xhosa</option>
+                                    <option value="yi">Yiddish</option>
+                                    <option value="ji">Yiddish</option>
+                                    <option value="yo">Yoruba</option>
+                                    <option value="za">Zhuang, Chuang</option>
+                                    <option value="zu">Zulu</option>
+                                </select>                          
+                                <!-- Include in Sitemap? -->
                                 <div class="card mb-3 d-none" id="sitemap-option-wrapper">
                                     <div class="card-header">Include in Sitemap</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-sitemap-include">
                                             <option value="0">No</option>
                                             <option value="1">Yes</option>
                                         </select>
                                     </div>
                                 </div>
+                                <!-- Obfuscate JavaScript? -->
                                 <div class="card mb-3" id="obfuscatejs-option-wrapper">
-                                    <div class="card-header">Obfuscate Javascript</div>
+                                    <div class="card-header">Obfuscate JavaScript</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-obfuscatejs">
                                             <option value="0">No</option>
                                             <option value="1">Yes</option>
                                         </select>
                                     </div>
                                 </div>
+                                <!-- Use Wrapper Div (container container-flex) -->
                                 <div class="card mb-3">
                                     <div class="card-header">Wrap HTML in Container Div</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-use_container">
                                             <option value="1">Yes</option>
                                             <option value="0">No</option>
                                         </select>
                                     </div>
                                 </div>
+                                <!-- Main Navigation -->
                                 <div class="card mb-3">
                                     <div class="card-header">Main Navigation</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-main-navigation">
                                             <option selected value="0">None</option>
                                         </select>
                                     </div>
                                 </div>
+                                <!-- Side Navigation -->
                                 <div class="card mb-3">
                                     <div class="card-header">Side Navigation</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-side-navigation">
                                             <option selected value="0">None</option>
                                         </select>
                                     </div>
                                 </div>
+                                <!-- Footer -->
                                 <div class="card mb-3">
                                     <div class="card-header">Footer</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <select id="setting-footer">
                                             <option selected value="0">None</option>
                                         </select>
                                     </div>
                                 </div>
+                                <!-- Var name for Kyte Web Components -->
                                 <div class="card mb-3">
                                     <div class="card-header">Variable Name for Web Components</div>
                                     <div class="card-body">
-                                        <!-- <h5 class="card-title"></h5> -->
                                         <input type="text" class="form-control" id="webcomponent_obj_name" />
                                     </div>
                                 </div>
                             </div>
                         </div>
+                        <!-- End Settings -->
                     </div>
                 </div>
             </div>

--- a/app/site/index.html
+++ b/app/site/index.html
@@ -188,20 +188,218 @@
                     </div>
                 </div>
 
+                <!-- Settings -->
                 <div id="Settings" class="mt-2 d-none">
                     <div class="px-2">
+                        <!-- Site Alias -->
                         <div class="card mb-3">
                             <div class="card-header">Site Alias Domain</div>
                             <div class="card-body">
                                 <input type="text" class="form-control" name="aliasDomain" id="aliasDomain" />
                             </div>
                         </div>
+                        <!-- Site Language -->
+                        <select name="default_lang" id="default_lang">
+                            <option value="ab">Abkhazian</option>
+                            <option value="aa">Afar</option>
+                            <option value="af">Afrikaans</option>
+                            <option value="ak">Akan</option>
+                            <option value="sq">Albanian</option>
+                            <option value="am">Amharic</option>
+                            <option value="ar">Arabic</option>
+                            <option value="an">Aragonese</option>
+                            <option value="hy">Armenian</option>
+                            <option value="as">Assamese</option>
+                            <option value="av">Avaric</option>
+                            <option value="ae">Avestan</option>
+                            <option value="ay">Aymara</option>
+                            <option value="az">Azerbaijani</option>
+                            <option value="bm">Bambara</option>
+                            <option value="ba">Bashkir</option>
+                            <option value="eu">Basque</option>
+                            <option value="be">Belarusian</option>
+                            <option value="bn">Bengali (Bangla)</option>
+                            <option value="bh">Bihari</option>
+                            <option value="bi">Bislama</option>
+                            <option value="bs">Bosnian</option>
+                            <option value="br">Breton</option>
+                            <option value="bg">Bulgarian</option>
+                            <option value="my">Burmese</option>
+                            <option value="ca">Catalan</option>
+                            <option value="ch">Chamorro</option>
+                            <option value="ce">Chechen</option>
+                            <option value="ny">Chichewa, Chewa, Nyanja</option>
+                            <option value="zh">Chinese</option>
+                            <option value="zh-Hans">Chinese (Simplified)</option>
+                            <option value="zh-Hant">Chinese (Traditional)</option>
+                            <option value="cv">Chuvash</option>
+                            <option value="kw">Cornish</option>
+                            <option value="co">Corsican</option>
+                            <option value="cr">Cree</option>
+                            <option value="hr">Croatian</option>
+                            <option value="cs">Czech</option>
+                            <option value="da">Danish</option>
+                            <option value="dv">Divehi, Dhivehi, Maldivian</option>
+                            <option value="nl">Dutch</option>
+                            <option value="dz">Dzongkha</option>
+                            <option value="en">English</option>
+                            <option value="eo">Esperanto</option>
+                            <option value="et">Estonian</option>
+                            <option value="ee">Ewe</option>
+                            <option value="fo">Faroese</option>
+                            <option value="fj">Fijian</option>
+                            <option value="fi">Finnish</option>
+                            <option value="fr">French</option>
+                            <option value="ff">Fula, Fulah, Pulaar, Pular</option>
+                            <option value="gl">Galician</option>
+                            <option value="gd">Gaelic (Scottish)</option>
+                            <option value="gv">Gaelic (Manx)</option>
+                            <option value="ka">Georgian</option>
+                            <option value="de">German</option>
+                            <option value="el">Greek</option>
+                            <option value="kl">Greenlandic</option>
+                            <option value="gn">Guarani</option>
+                            <option value="gu">Gujarati</option>
+                            <option value="ht">Haitian Creole</option>
+                            <option value="ha">Hausa</option>
+                            <option value="he">Hebrew</option>
+                            <option value="hz">Herero</option>
+                            <option value="hi">Hindi</option>
+                            <option value="ho">Hiri Motu</option>
+                            <option value="hu">Hungarian</option>
+                            <option value="is">Icelandic</option>
+                            <option value="io">Ido</option>
+                            <option value="ig">Igbo</option>
+                            <option value="id">Indonesian</option>
+                            <option value="in">Indonesian</option>
+                            <option value="ia">Interlingua</option>
+                            <option value="ie">Interlingue</option>
+                            <option value="iu">Inuktitut</option>
+                            <option value="ik">Inupiak</option>
+                            <option value="ga">Irish</option>
+                            <option value="it">Italian</option>
+                            <option value="ja">Japanese</option>
+                            <option value="jv">Javanese</option>
+                            <option value="kn">Kannada</option>
+                            <option value="kr">Kanuri</option>
+                            <option value="ks">Kashmiri</option>
+                            <option value="kk">Kazakh</option>
+                            <option value="km">Khmer</option>
+                            <option value="ki">Kikuyu</option>
+                            <option value="rw">Kinyarwanda (Rwanda)</option>
+                            <option value="rn">Kirundi</option>
+                            <option value="ky">Kyrgyz</option>
+                            <option value="kv">Komi</option>
+                            <option value="kg">Kongo</option>
+                            <option value="ko">Korean</option>
+                            <option value="ku">Kurdish</option>
+                            <option value="kj">Kwanyama</option>
+                            <option value="lo">Lao</option>
+                            <option value="la">Latin</option>
+                            <option value="lv">Latvian (Lettish)</option>
+                            <option value="li">Limburgish (Limburger)</option>
+                            <option value="ln">Lingala</option>
+                            <option value="lt">Lithuanian</option>
+                            <option value="lu">Luga-Katanga</option>
+                            <option value="lg">Luganda, Ganda</option>
+                            <option value="lb">Luxembourgish</option>
+                            <option value="mk">Macedonian</option>
+                            <option value="mg">Malagasy</option>
+                            <option value="ms">Malay</option>
+                            <option value="ml">Malayalam</option>
+                            <option value="mt">Maltese</option>
+                            <option value="mi">Maori</option>
+                            <option value="mr">Marathi</option>
+                            <option value="mh">Marshallese</option>
+                            <option value="mo">Moldavian</option>
+                            <option value="mn">Mongolian</option>
+                            <option value="na">Nauru</option>
+                            <option value="nv">Navajo</option>
+                            <option value="ng">Ndonga</option>
+                            <option value="nd">Northern Ndebele</option>
+                            <option value="ne">Nepali</option>
+                            <option value="no">Norwegian</option>
+                            <option value="nb">Norwegian bokmål</option>
+                            <option value="nn">Norwegian nynorsk</option>
+                            <option value="ii">Nuosu</option>
+                            <option value="oc">Occitan</option>
+                            <option value="oj">Ojibwe</option>
+                            <option value="cu">Old Church Slavonic, Old Bulgarian</option>
+                            <option value="or">Oriya</option>
+                            <option value="om">Oromo (Afaan Oromo)</option>
+                            <option value="os">Ossetian</option>
+                            <option value="pi">Pāli</option>
+                            <option value="ps">Pashto, Pushto</option>
+                            <option value="fa">Persian (Farsi)</option>
+                            <option value="pl">Polish</option>
+                            <option value="pt">Portuguese</option>
+                            <option value="pa">Punjabi (Eastern)</option>
+                            <option value="qu">Quechua</option>
+                            <option value="rm">Romansh</option>
+                            <option value="ro">Romanian</option>
+                            <option value="ru">Russian</option>
+                            <option value="se">Sami</option>
+                            <option value="sm">Samoan</option>
+                            <option value="sg">Sango</option>
+                            <option value="sa">Sanskrit</option>
+                            <option value="sr">Serbian</option>
+                            <option value="sh">Serbo-Croatian</option>
+                            <option value="st">Sesotho</option>
+                            <option value="tn">Setswana</option>
+                            <option value="sn">Shona</option>
+                            <option value="ii">Sichuan Yi</option>
+                            <option value="sd">Sindhi</option>
+                            <option value="si">Sinhalese</option>
+                            <option value="ss">Siswati</option>
+                            <option value="sk">Slovak</option>
+                            <option value="sl">Slovenian</option>
+                            <option value="so">Somali</option>
+                            <option value="nr">Southern Ndebele</option>
+                            <option value="es">Spanish</option>
+                            <option value="su">Sundanese</option>
+                            <option value="sw">Swahili (Kiswahili)</option>
+                            <option value="ss">Swati</option>
+                            <option value="sv">Swedish</option>
+                            <option value="tl">Tagalog</option>
+                            <option value="ty">Tahitian</option>
+                            <option value="tg">Tajik</option>
+                            <option value="ta">Tamil</option>
+                            <option value="tt">Tatar</option>
+                            <option value="te">Telugu</option>
+                            <option value="th">Thai</option>
+                            <option value="bo">Tibetan</option>
+                            <option value="ti">Tigrinya</option>
+                            <option value="to">Tonga</option>
+                            <option value="ts">Tsonga</option>
+                            <option value="tr">Turkish</option>
+                            <option value="tk">Turkmen</option>
+                            <option value="tw">Twi</option>
+                            <option value="ug">Uyghur</option>
+                            <option value="uk">Ukrainian</option>
+                            <option value="ur">Urdu</option>
+                            <option value="uz">Uzbek</option>
+                            <option value="ve">Venda</option>
+                            <option value="vi">Vietnamese</option>
+                            <option value="vo">Volapük</option>
+                            <option value="wa">Wallon</option>
+                            <option value="cy">Welsh</option>
+                            <option value="wo">Wolof</option>
+                            <option value="fy">Western Frisian</option>
+                            <option value="xh">Xhosa</option>
+                            <option value="yi">Yiddish</option>
+                            <option value="ji">Yiddish</option>
+                            <option value="yo">Yoruba</option>
+                            <option value="za">Zhuang, Chuang</option>
+                            <option value="zu">Zulu</option>
+                        </select>
+                        <!-- Google Analytics -->
                         <div class="card mb-3">
                             <div class="card-header">Google Analytics</div>
                             <div class="card-body">
                                 <input type="text" class="form-control" name="ga_code" id="ga_code" />
                             </div>
                         </div>
+                        <!-- Google Tag Manager -->
                         <div class="card mb-3">
                             <div class="card-header">Google Tag Manager</div>
                             <div class="card-body">
@@ -213,7 +411,7 @@
                         </div>
                     </div>
                 </div>
-
+                <!-- End Settings -->
             </div>
         </main>
     </div>

--- a/assets/js/source/kyte-shipyard-page-block-editor.js
+++ b/assets/js/source/kyte-shipyard-page-block-editor.js
@@ -94,6 +94,7 @@ document.addEventListener('KyteInitialized', function(e) {
                 // set page title and description
                 $("#setting-page-title").val(pageData.page.title);
                 $("#setting-page-description").val(pageData.page.description);
+                $("#lang").val(pageData.page.lang.length == 0 ? 'default' : pageData.page.leng);
 
                 if (pageData.page.protected == 0) {
                     $("#sitemap-option-wrapper").removeClass('d-none');
@@ -252,6 +253,7 @@ document.addEventListener('KyteInitialized', function(e) {
                         'side_navigation': $("#setting-side-navigation").val(),
                         'title': $("#setting-page-title").val(),
                         'description': $("#setting-page-description").val(),
+                        'lang':$("#lang").val() == 'default' ? null : $("#lang").val(),
                         'sitemap_include': $("#setting-sitemap-include").val(),
                         'block_layout': JSON.stringify(blockEditor.getProjectData()),
                         'page_type': 'block',
@@ -302,6 +304,7 @@ document.addEventListener('KyteInitialized', function(e) {
                         'footer': $("#setting-footer").val(),
                         'title': $("#setting-page-title").val(),
                         'description': $("#setting-page-description").val(),
+                        'lang':$("#lang").val() == 'default' ? null : $("#lang").val(),
                         'sitemap_include': $("#setting-sitemap-include").val(),
                         'obfuscate_js': $("#setting-obfuscatejs").val(),
                         'use_container': $("#setting-use_container").val(),

--- a/assets/js/source/kyte-shipyard-page-code-editor.js
+++ b/assets/js/source/kyte-shipyard-page-code-editor.js
@@ -117,6 +117,7 @@ document.addEventListener('KyteInitialized', function(e) {
                 $("#setting-page-title").val(pageData.page.title);
                 $("#setting-page-description").val(pageData.page.description);
                 $("#webcomponent_obj_name").val(pageData.page.webcomponent_obj_name);
+                $("#lang").val(pageData.page.lang.length == 0 ? 'default' : pageData.page.leng);
                 
                 // if block editor, redirect to block editor page.
                 if (pageData.page.page_type == 'block' && !forceCodeEditor) {
@@ -336,6 +337,7 @@ document.addEventListener('KyteInitialized', function(e) {
                             'footer':$("#setting-footer").val(),
                             'title':$("#setting-page-title").val(),
                             'description':$("#setting-page-description").val(),
+                            'lang':$("#lang").val() == 'default' ? null : $("#lang").val(),
                             'webcomponent_obj_name': $("#webcomponent_obj_name").val(),
                             'sitemap_include':$("#setting-sitemap-include").val(),
                             'obfuscate_js':$("#setting-obfuscatejs").val(),
@@ -390,6 +392,7 @@ document.addEventListener('KyteInitialized', function(e) {
                             'footer':$("#setting-footer").val(),
                             'title':$("#setting-page-title").val(),
                             'description':$("#setting-page-description").val(),
+                            'lang':$("#lang").val() == 'default' ? null : $("#lang").val(),
                             'webcomponent_obj_name': $("#webcomponent_obj_name").val(),
                             'sitemap_include':$("#setting-sitemap-include").val(),
                             'obfuscate_js':$("#setting-obfuscatejs").val(),

--- a/assets/js/source/kyte-shipyard-site-details.js
+++ b/assets/js/source/kyte-shipyard-site-details.js
@@ -318,6 +318,7 @@ document.addEventListener('KyteInitialized', function(e) {
                 $("#domain-name").attr('href', 'https://'+(data.aliasDomain ? data.aliasDomain : data.cfDomain));
                 $("#region").html(data.region);
                 $("#aliasDomain").val(data.aliasDomain);
+                $("#default_lang").val(data.default_lang);
                 $("#ga_code").val(data.ga_code);
                 $("#gtm_code").val(data.gtm_code);
 
@@ -446,12 +447,14 @@ document.addEventListener('KyteInitialized', function(e) {
             e.preventDefault();
 
             let aliasDomain = $("#aliasDomain").val();
+            let default_lang = $("#default_lang").val();
             let ga_code = $("#ga_code").val();
             let gtm_code = $("#gtm_code").val();
 
             _ks.put('KyteSite', 'id', idx,
             {
                 'aliasDomain':aliasDomain,
+                'default_lang':default_lang.length > 0 ? default_lang : 'en',
                 'ga_code':ga_code,
                 'gtm_code':gtm_code,
             }, null, [], function(r) {


### PR DESCRIPTION
### Changes Proposed in This PR
Add language option to site and page settings. Site langauge will be default is page settings is not configured. Page settings will override site-wide settings.

### Acceptance Criteria Scenarios
Check if selected language is correctly reflected in backend and page that is generated.

### Linked Issues
Issue #9

### Implementation Details
n/a

### Dependencies
n/a

### Testing Strategy
Check if selected language is correctly reflected in backend and page that is generated.

### Screenshots/Video
n/a

### Checklist Before Requesting Review
- [ ] Changes are complete and tested.
- [ ] Pull request targets the correct branch.
- [ ] Code is consistent with the existing codebase.
- [ ] Linter/static analysis passes.
- [ ] Existing tests pass.
- [ ] Documentation and changelog are updated.

### Instructions for Reviewers
n/a

### Follow-Up Tasks (If Applicable)
n/a

### Additional Notes
n/a
