### PR TITLE
Add timer to check page creation status and spinning fa icon (#7)

### DIFF
--- a/assets/js/source/kyte-shipyard-site-details.js
+++ b/assets/js/source/kyte-shipyard-site-details.js
@@ -311,7 +311,17 @@ document.addEventListener('KyteInitialized', function(e) {
                 data = r.data[0];
                 // if site is not active display a message
                 if (data.status != 'active') {
-                    $("#site-detail-page-wrapper").html(`<div class="container"><div class="my-5 alert alert-info text-center" role="alert"><i class="my-3 d-block fas fa-exclamation fa-3x"></i><h3>We are ${data.status} your site.</h3><h4 style="font-weight:300">Please wait until the operation is completed.</h4></div></div>`)
+                    $("#site-detail-page-wrapper").html(`<div class="container"><div class="my-5 alert alert-info text-center" role="alert"><i class="my-3 d-block fas fa-exclamation fa-3x"></i><h3>We are ${data.status} your site.</h3><h4 style="font-weight:300">Please wait until the operation is completed.</h4><span class="fas fa-sync fa-spin my-4"></span></div></div>`);
+                    if (data.status == 'creating') {
+                        // check status every minute
+                        setTimeout(function() {
+                            _ks.get("KyteSite", "id", idx, [], function(r) {
+                                if (r.data[0].status == 'active') {
+                                    location.reload();
+                                }
+                            });
+                        }, 6000);
+                    }
                 }
                 $("#site-name").html(data.name);
                 $("#domain-name").html('<i class="fas fa-link me-2"></i>'+(data.aliasDomain ? data.aliasDomain : data.cfDomain));


### PR DESCRIPTION
### Changes Proposed in This PR
Add timer that will check every minute on the status of a new site being created. Also added a FontAwesome spinner to indicate creation processes.

### Acceptance Criteria Scenarios
Displays spinner correctly when creating a site. Periodically checks the creation status and refreshes once the site has been created and is active.

### Linked Issues
Issue #7 

### Implementation Details
n/a

### Dependencies
n/a

### Testing Strategy
Displays spinner correctly when creating a site. Periodically checks the creation status and refreshes once the site has been created and is active.

### Screenshots/Video
n/a

### Checklist Before Requesting Review
- [ ] Changes are complete and tested.
- [ ] Pull request targets the correct branch.
- [ ] Code is consistent with the existing codebase.
- [ ] Linter/static analysis passes.
- [ ] Existing tests pass.
- [ ] Documentation and changelog are updated.

### Instructions for Reviewers
n/a

### Follow-Up Tasks (If Applicable)
n/a

### Additional Notes
n/a
