### PR TITLE
fix(config): auth_mode toggle regenerates systemKyteCode before republish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 2.0.1
+
+### Bug Fix: auth_mode toggle was republishing pages with the OLD (HMAC) connect string
+
+In 2.0.0, the auth_mode toggle on /app/configuration.html called `updateKyteConnectCode(_ks)` (which sets `republish_kyte_connect=1` on the Application — the same path the obfuscation toggle uses for backend page-republish). But it did so BEFORE regenerating `systemKyteCode` against the new app.auth_mode. Result: the server triggered republish, but with the stale HMAC-shape connect string. Operators flipped HMAC → JWT in the UI, the "republish" message said it worked, but the pages out there still embedded the HMAC `new Kyte(...)` call.
+
+Fix: call `initializeKyteConnectComparison()` (which regenerates `systemKyteCode` from the now-updated app.auth_mode) BEFORE `updateKyteConnectCode(_ks)`. The republish now carries the correct shape.
+
+User-visible effect: flipping the Authentication Mode toggle and clicking Save now actually republishes every page with the new connect string. No need to manually republish each page through the page editor.
+
 ## 2.0.0
 
 ### Breaking Change: default to JWT bearer authentication

--- a/assets/js/source/kyte-shipyard-application-configuration.js
+++ b/assets/js/source/kyte-shipyard-application-configuration.js
@@ -885,21 +885,30 @@ function saveAuthModeSettings(_ks, idx) {
 
     _ks.put('Application', 'id', idx, updateData, null, [], function(r) {
         if (r.data && r.data.length > 0) {
-            // Update the in-memory app object so subsequent Connect-code
-            // regeneration uses the new mode.
+            // 1. Mirror the new auth_mode into the local app object so
+            //    generateSystemKyteCode() emits the right constructor shape.
             app = {...app, ...updateData};
 
-            // Regenerate the Connect code on change so the comparison panel
-            // immediately reflects the new constructor shape.
             if (currentAuthMode !== newAuthMode) {
-                updateKyteConnectCode(_ks);
-            }
-
-            showSuccess("Authentication mode updated. Republish any deployed pages to apply the new connect string.");
-
-            // Refresh the comparison panel if it's currently visible.
-            if (document.getElementById('KyteConnect').classList.contains('active')) {
+                // 2. Regenerate systemKyteCode against the NEW auth_mode
+                //    before pushing. initializeKyteConnectComparison sets
+                //    `systemKyteCode = generateSystemKyteCode()` and also
+                //    refreshes the comparison panel. Without this step,
+                //    updateKyteConnectCode would push the *stale* code
+                //    (the HMAC shape) and the republish flag would carry
+                //    the wrong content to every published page.
                 initializeKyteConnectComparison();
+
+                // 3. Same path the obfuscation toggle uses — sets
+                //    kyte_connect / kyte_connect_obfuscated /
+                //    republish_kyte_connect=1 on Application, which the
+                //    backend reacts to by republishing every page that
+                //    embeds the connect string.
+                updateKyteConnectCode(_ks);
+
+                showSuccess("Authentication mode updated. All published pages will be republished with the new connect string.");
+            } else {
+                showSuccess("Authentication mode unchanged.");
             }
         } else {
             showError("Unable to update authentication mode. Please try again or contact support.");

--- a/assets/js/source/kyte-shipyard.js
+++ b/assets/js/source/kyte-shipyard.js
@@ -1,4 +1,4 @@
-var KS_VERSION = '2.0.0';
+var KS_VERSION = '2.0.1';
 
 function loadScript(url, callback) {
     var script = document.createElement('script');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kyte-shipyard",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "private": true,
   "description": "Kyte Shipyard — admin UI for the Kyte platform. Sources in assets/js/source/, esbuild minifies to assets/js/ (gitignored).",
   "type": "module",


### PR DESCRIPTION
## Summary

Shipyard v2.0.0 had an ordering bug in saveAuthModeSettings on /app/configuration.html: it triggered backend republish (republish_kyte_connect=1) BEFORE regenerating the system connect code against the new auth_mode. Result: published pages stayed on the OLD connect string after flipping HMAC ↔ JWT.

## Fix

Call initializeKyteConnectComparison() (regenerates systemKyteCode) before updateKyteConnectCode(_ks) (uploads + flags republish).

## Test plan

- [x] npm run build clean
- [x] All 4 i18n locales remain valid
- [x] Manually verified on localhost:8000 — flipping HMAC ↔ JWT now sends TWO PUTs: first {auth_mode}, second {kyte_connect, kyte_connect_obfuscated, republish_kyte_connect:1} carrying the NEW shape
- [x] Version sync: KS_VERSION + package.json + CHANGELOG all at 2.0.1

Patch v2.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)