### PR TITLE
IDE Publish action (#189) + Republish-all / republish result UI (#181) — 2.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## 2.2.0
 
+### Feature: "Republish all pages" + per-page republish result (KYTE-#181)
+
+Pairs with kyte-php v4.8.1, which makes the republish hook fault-isolated and returns a `republish_summary`. On the app **configuration page**:
+
+- A **"Republish all pages"** button (on the Authentication Mode card) — an explicit recovery action that re-stamps and re-deploys every published page with the current Kyte Connect code, then reports the result. Useful when an auto-republish half-completed.
+- The **per-page result is now surfaced**: the auth-mode flip / kyte-connect update and the new button all read `republish_summary` and show how many pages succeeded/failed (failures are listed and logged to the console) — instead of a blind "it worked" toast.
+
 ### Feature: Publish action in the IDE (KYTE-#189)
 
 The in-app IDE could only Save (which persists content); there was no way to publish from it. Added a **Publish** action for publishable file types (**pages** and **scripts** — the ones that deploy to S3):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.2.0
+
+### Feature: Publish action in the IDE (KYTE-#189)
+
+The in-app IDE could only Save (which persists content); there was no way to publish from it. Added a **Publish** action for publishable file types (**pages** and **scripts** — the ones that deploy to S3):
+
+- A green **rocket** button in the IDE tab bar, shown only when the active file is a page or script.
+- **Ctrl+Shift+S** keyboard shortcut (Save remains Ctrl+S); added to the welcome-screen shortcut list.
+- Publishing sends `state=1` alongside the content, so the backend runs its normal publish path (page → `publishPage` → S3 + CloudFront; script → `handleScriptPublication` → S3) and creates a version with the change summary. Unlike Save, Publish is allowed even when the file isn't dirty (re-deploy current content), and it persists any pending edits in the same request.
+
+Pairs with kyte-php v4.8.1 (`block_layout` partial-save guard). The "IDE save didn't persist" issue from #189 was already fixed by kyte-php v4.8.0.
+
 ## 2.1.0
 
 ### Change: remove JavaScript obfuscation (pairs with kyte-php v4.7.0 — KYTE-#191)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 2.2.0
 
+### Improvement: show the file path under the name in the IDE explorer
+
+Pages and scripts in the IDE file tree now show their **path** (`s3key`) in a muted second line under the file name. Same-named files (common for pages) are now distinguishable at a glance without having to open each one. The full path is also available as a hover tooltip.
+
 ### Feature: "Republish all pages" + per-page republish result (KYTE-#181)
 
 Pairs with kyte-php v4.8.1, which makes the republish hook fault-isolated and returns a `republish_summary`. On the app **configuration page**:

--- a/app/configuration.html
+++ b/app/configuration.html
@@ -376,8 +376,12 @@
                                 <option value="jwt" data-i18n="ui.config.kyte_connect.auth_mode.jwt">JWT Bearer (Recommended — rotating tokens)</option>
                             </select>
                         </div>
-                        <!-- Save Button -->
-                        <div class="d-flex justify-content-end">
+                        <!-- Action Buttons -->
+                        <div class="d-flex justify-content-between align-items-center">
+                            <button id="republishAllPages" class="btn btn-outline-secondary" title="Re-stamp and re-deploy every published page with the current Kyte Connect code">
+                                <i class="fas fa-sync-alt me-2"></i>
+                                <span>Republish all pages</span>
+                            </button>
                             <button id="saveAuthModeSettings" class="btn btn-primary">
                                 <i class="fas fa-save me-2"></i>
                                 <span data-i18n="ui.config.kyte_connect.auth_mode.save_button">Save Authentication Mode</span>

--- a/app/ide/index.html
+++ b/app/ide/index.html
@@ -141,6 +141,10 @@
                                 <span>Save current file</span>
                             </div>
                             <div class="shortcut-item">
+                                <span class="shortcut-key">Ctrl+Shift+S</span>
+                                <span>Publish current file (pages &amp; scripts)</span>
+                            </div>
+                            <div class="shortcut-item">
                                 <span class="shortcut-key">Ctrl+W</span>
                                 <span>Close current tab</span>
                             </div>

--- a/assets/css/kyte-ide.css
+++ b/assets/css/kyte-ide.css
@@ -261,6 +261,23 @@ body, html {
     text-overflow: ellipsis;
 }
 
+/* Stacked name + path (pages & scripts) so same-named files are distinguishable */
+.tree-item .file-meta {
+    display: flex;
+    flex-direction: column;
+    flex: 1 1 auto;
+    min-width: 0;
+    overflow: hidden;
+}
+
+.tree-item .file-path {
+    font-size: 0.68rem;
+    color: #6a6a6a;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
 .tree-item .dirty-indicator {
     margin-left: auto;
     width: 8px;

--- a/assets/js/source/kyte-shipyard-application-configuration.js
+++ b/assets/js/source/kyte-shipyard-application-configuration.js
@@ -250,6 +250,12 @@ function setupFormEventHandlers(_ks, idx) {
         e.preventDefault();
         saveAuthModeSettings(_ks, idx);
     });
+
+    // Republish all pages handler (KYTE-#181)
+    $("#republishAllPages").click(function(e) {
+        e.preventDefault();
+        republishAllPages(_ks, idx);
+    });
 }
 
 // Handle user model change
@@ -633,13 +639,21 @@ function updateKyteConnectCode(_ks) {
             // Update local app object
             app.kyte_connect = systemKyteCode;
             app.kyte_connect_obfuscated = '';
-            
+
             // Update current code and refresh comparison
             currentKyteCode = systemKyteCode;
             displayKyteCodes();
             compareKyteCodes();
-            
-            showSuccess('Kyte Connect code updated successfully!');
+
+            // Surface the per-page republish result (KYTE-#181)
+            const formatted = formatRepublishSummary(r.data[0] && r.data[0].republish_summary);
+            if (formatted && !formatted.ok) {
+                showError('Kyte Connect updated, but some pages failed to republish. ' + formatted.message);
+            } else if (formatted) {
+                showSuccess('Kyte Connect code updated. ' + formatted.message);
+            } else {
+                showSuccess('Kyte Connect code updated successfully!');
+            }
         } else {
             showError('Failed to update Kyte Connect code. Please try again.');
         }
@@ -650,6 +664,46 @@ function updateKyteConnectCode(_ks) {
         showError('Failed to update Kyte Connect code: ' + err);
         updateButton.innerHTML = originalText;
         updateButton.disabled = false;
+    });
+}
+
+// Format the backend's republish_summary (KYTE-#181) into a user-facing result.
+// Returns { ok: bool, message: string } or null when no summary is present.
+function formatRepublishSummary(summary) {
+    if (!summary) return null;
+    const ok = summary.succeeded || 0;
+    const failed = summary.failed || 0;
+    const total = ok + failed;
+    if (failed === 0) {
+        return { ok: true, message: `Republished ${ok} page${ok === 1 ? '' : 's'}.` };
+    }
+    console.warn('Republish failures:', summary.failures);
+    const detail = (summary.failures || [])
+        .map(f => `page ${f.page}${f.s3key ? ' (' + f.s3key + ')' : ''}`)
+        .join(', ');
+    return { ok: false, message: `Republished ${ok} of ${total} pages — ${failed} failed: ${detail}. See console for details.` };
+}
+
+// Explicitly re-stamp and re-deploy every published page with the CURRENT Kyte
+// Connect code, and report a per-page result. Recovery action for a half-completed
+// auto-republish. See KYTE-#181.
+function republishAllPages(_ks, idx) {
+    const btn = $("#republishAllPages");
+    const original = btn.html();
+    btn.html('<i class="fas fa-spinner fa-spin me-2"></i>Republishing...').prop('disabled', true);
+
+    _ks.put('Application', 'id', idx, { 'republish_kyte_connect': 1 }, null, [], function(r) {
+        const summary = (r.data && r.data[0]) ? r.data[0].republish_summary : null;
+        const formatted = formatRepublishSummary(summary);
+        if (formatted && !formatted.ok) {
+            showError(formatted.message);
+        } else {
+            showSuccess(formatted ? formatted.message : 'All pages republished.');
+        }
+        btn.html(original).prop('disabled', false);
+    }, function(err) {
+        showError('Republish failed: ' + err);
+        btn.html(original).prop('disabled', false);
     });
 }
 

--- a/assets/js/source/kyte-shipyard-ide.js
+++ b/assets/js/source/kyte-shipyard-ide.js
@@ -65,6 +65,7 @@ const FILE_TYPES = {
         iconClass: 'html',
         sectionIcon: 'fas fa-sitemap',
         model: 'KytePage',
+        publishable: true,           // can be published to S3 (state=1 → publishPage)
         loadModel: 'KytePageData',   // Special loader: uses KytePageData to get content
         loadField: 'page',            // KytePageData is keyed by 'page' field
         listField: 'site',
@@ -119,6 +120,7 @@ const FILE_TYPES = {
         iconClass: 'js',
         sectionIcon: 'fas fa-scroll',
         model: 'KyteScript',
+        publishable: true,           // can be published to S3 (state=1 → handleScriptPublication)
         listField: 'site',
         parts: [
             { key: 'content', label: 'JavaScript', language: 'javascript', field: 'content' }
@@ -690,7 +692,16 @@ function renderTabs() {
         </button>
     `;
 
-    tabBar.innerHTML = tabsHtml + historyBtnHtml;
+    // Show a Publish button only for publishable file types (pages, scripts → S3)
+    const isPublishable = activeTab && activeTab.fileType.publishable;
+    const publishBtnHtml = `
+        <button class="history-toggle-btn ide-publish-btn ${isPublishable ? '' : 'hidden'}"
+                onclick="window.kyteIDE.publishActiveFile()" title="Publish to live site (Ctrl+Shift+S)">
+            <i class="fas fa-rocket" style="color:#34c759;"></i>
+        </button>
+    `;
+
+    tabBar.innerHTML = tabsHtml + publishBtnHtml + historyBtnHtml;
 }
 
 function renderSubTabs(tab) {
@@ -872,7 +883,7 @@ function saveFile(fileId, callback) {
     }
 }
 
-function performSave(fileId, fileType, itemId, buf, changeSummary, callback) {
+function performSave(fileId, fileType, itemId, buf, changeSummary, callback, publish) {
     // Build update data
     const data = {};
     fileType.parts.forEach(part => {
@@ -884,13 +895,19 @@ function performSave(fileId, fileType, itemId, buf, changeSummary, callback) {
         data.change_summary = changeSummary;
     }
 
+    // Publish: state=1 triggers the backend publish (page → S3 via publishPage,
+    // script → S3 via handleScriptPublication). Save without it just persists.
+    if (publish) {
+        data.state = 1;
+    }
+
     // For Pages, the save target is KytePage and the ID is from the nested page object
     const saveModel = fileType.model;
     const saveId = (fileType.id === 'page' && buf.item && buf.item.page)
         ? buf.item.page.id
         : itemId;
 
-    notify('info', 'Saving...');
+    notify('info', publish ? 'Publishing...' : 'Saving...');
 
     _ks.put(saveModel, 'id', saveId, data, null, [], function(r) {
         // Update original to match current (no longer dirty)
@@ -900,7 +917,7 @@ function performSave(fileId, fileType, itemId, buf, changeSummary, callback) {
 
         updateDirtyIndicators(fileId);
         renderTabs();
-        notify('success', 'Saved successfully');
+        notify('success', publish ? 'Published successfully' : 'Saved successfully');
 
         // Refresh version history if panel is open
         if (historyPanelOpen && activeTabId === fileId) {
@@ -909,13 +926,52 @@ function performSave(fileId, fileType, itemId, buf, changeSummary, callback) {
 
         if (callback) callback();
     }, function(err) {
-        notify('error', 'Save failed: ' + err);
+        notify('error', (publish ? 'Publish failed: ' : 'Save failed: ') + err);
     });
 }
 
 function saveActiveFile() {
     if (activeTabId) {
         saveFile(activeTabId);
+    }
+}
+
+// Publish the active file to its live site (pages/scripts → S3). Unlike save,
+// publishing is allowed even when not dirty (re-deploy current content). It also
+// persists any pending edits in the same request (state=1 + content). See KYTE-#189.
+function publishActiveFile() {
+    if (activeTabId) {
+        publishFile(activeTabId);
+    }
+}
+
+function publishFile(fileId, callback) {
+    const buf = fileBuffers[fileId];
+    if (!buf) return;
+
+    const { fileType, itemId } = parseFileId(fileId);
+
+    if (!fileType.publishable) {
+        notify('info', 'This file type deploys automatically on save — no separate publish.');
+        return;
+    }
+
+    // Flush current editor content to buffer
+    if (activeTabId === fileId) {
+        saveEditorToBuffer();
+    }
+
+    // Versioned types capture a change summary (publish also creates a version)
+    if (fileType.versioning) {
+        showChangeSummaryModal(function(action, summary) {
+            if (action === 'cancel') {
+                return;
+            }
+            const changeSummary = action === 'save' ? summary : '';
+            performSave(fileId, fileType, itemId, buf, changeSummary, callback, true);
+        });
+    } else {
+        performSave(fileId, fileType, itemId, buf, null, callback, true);
     }
 }
 
@@ -1196,8 +1252,15 @@ function initKeyboardShortcuts() {
     document.addEventListener('keydown', function(e) {
         const isCtrl = e.ctrlKey || e.metaKey;
 
+        // Ctrl+Shift+S — Publish
+        if (isCtrl && e.shiftKey && (e.key === 's' || e.key === 'S')) {
+            e.preventDefault();
+            publishActiveFile();
+            return;
+        }
+
         // Ctrl+S — Save
-        if (isCtrl && e.key === 's') {
+        if (isCtrl && !e.shiftKey && e.key === 's') {
             e.preventDefault();
             saveActiveFile();
         }
@@ -1345,6 +1408,7 @@ window.kyteIDE = {
     toggleSection,
     toggleGroup,
     saveActiveFile,
+    publishActiveFile,
     collapseAll,
     toggleHistory,
     restoreVersion

--- a/assets/js/source/kyte-shipyard-ide.js
+++ b/assets/js/source/kyte-shipyard-ide.js
@@ -407,6 +407,7 @@ function renderPagesSection() {
         html += renderGroup(site.name || 'Unnamed Site', 'fas fa-globe', site._pages.map(page => ({
             fileId: generateFileId(FILE_TYPES.PAGE, page.id),
             name: FILE_TYPES.PAGE.displayName(page),
+            path: page.s3key || '',
             iconClass: FILE_TYPES.PAGE.iconClass,
             icon: FILE_TYPES.PAGE.icon
         })));
@@ -439,6 +440,7 @@ function renderScriptsSection() {
             return {
                 fileId: generateFileId(FILE_TYPES.SCRIPT, script.id),
                 name: FILE_TYPES.SCRIPT.displayName(script),
+                path: script.s3key || '',
                 iconClass: isCss ? 'css' : 'js',
                 icon: isCss ? 'fab fa-css3-alt' : 'fab fa-js'
             };
@@ -475,9 +477,12 @@ function renderGroup(label, icon, items) {
             </div>
             <div class="tree-group-items">
                 ${items.map(item => `
-                    <div class="tree-item nested" data-file-id="${item.fileId}" onclick="window.kyteIDE.openFile('${item.fileId}')">
+                    <div class="tree-item nested" data-file-id="${item.fileId}" onclick="window.kyteIDE.openFile('${item.fileId}')" title="${escapeHtml(item.path || item.name)}">
                         <i class="file-icon ${item.iconClass} ${item.icon}"></i>
-                        <span class="file-name">${escapeHtml(item.name)}</span>
+                        <span class="file-meta">
+                            <span class="file-name">${escapeHtml(item.name)}</span>
+                            ${item.path ? `<span class="file-path">${escapeHtml(item.path)}</span>` : ''}
+                        </span>
                         <span class="dirty-indicator"></span>
                     </div>
                 `).join('')}

--- a/assets/js/source/kyte-shipyard.js
+++ b/assets/js/source/kyte-shipyard.js
@@ -1,4 +1,4 @@
-var KS_VERSION = '2.1.0';
+var KS_VERSION = '2.2.0';
 
 function loadScript(url, callback) {
     var script = document.createElement('script');

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kyte-shipyard",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "private": true,
   "description": "Kyte Shipyard — admin UI for the Kyte platform. Sources in assets/js/source/, esbuild minifies to assets/js/ (gitignored).",
   "type": "module",


### PR DESCRIPTION
## IDE Publish action (#189) + "Republish all pages" / republish result UI (#181) — 2.2.0

Two related Shipyard UX additions, paired with kyte-php **v4.8.1** (PR keyqcloud/kyte-php#97).

### #189 — Publish action in the IDE
The in-app IDE could only **Save**; there was no way to **Publish** (deploy to S3) from it.
- **Green rocket button** in the IDE tab bar, shown only for publishable types (**pages** & **scripts**).
- **Ctrl+Shift+S** shortcut (Save stays Ctrl+S); added to the welcome-screen shortcuts.
- Publishing sends `state=1` with the content → backend runs its normal publish path (page → `publishPage` → S3 + CloudFront; script → `handleScriptPublication` → S3) and versions it. Allowed even when not dirty (re-deploy); persists pending edits in the same request.

### #181 — "Republish all pages" + per-page result
Pairs with kyte-php v4.8.1's fault-isolated republish (which returns a `republish_summary`).
- **"Republish all pages"** button on the Authentication Mode card — an explicit recovery action that re-stamps + re-deploys every published page with the current Kyte Connect code.
- The **per-page result is surfaced**: the auth-mode flip / kyte-connect update and the new button read `republish_summary` and report how many pages succeeded/failed (failures listed + logged), instead of a blind "it worked" toast.

Bumps to **2.2.0** (`KS_VERSION` + `package.json`). esbuild build passes.

Note: the "IDE save didn't persist" bug from #189 was already fixed by kyte-php v4.8.0's guard relaxation — confirmed working on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
