### PR TITLE
Password reset works in JWT mode via /jwt/password-* (KYTE-#268) — 2.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Shipyard is **platform-level** — it initializes the Kyte client with no `appli
 
 HMAC mode keeps the existing `KytePasswordReset` model-CRUD calls untouched. **Requires kyte-php v4.11.0+** for the `/jwt/password-*` endpoints.
 
+### Fix: password page UI bugs (surfaced during #268 QA)
+
+- The show/hide-password eye icons on password.html threw `ReferenceError: togglePassword is not defined` on every click in every deployment — the handler was scoped inside the `KyteInitialized` listener while the HTML wires it via inline `onclick`. Now exposed globally.
+- A failed password update displayed `[object Object]` — `showError` rendered the HMAC error-callback object directly. It now extracts the message string.
+
 ## 2.2.0
 
 ### Improvement: show the file path under the name in the IDE explorer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+## 2.3.0
+
+### Fix: password reset works in JWT mode (KYTE-#268)
+
+Shipyard is **platform-level** — it initializes the Kyte client with no `applicationId` — so in JWT mode its anonymous password-reset calls could ride neither the legacy HMAC-anonymous path nor the v4.11.0 `AppContextStrategy` (which requires an `x-kyte-appid`). Result: **password reset was broken on JWT-mode Shipyard** (the request failed closed before ever reaching the server).
+
+`reset.js` and `password.js` now call the dedicated kyte-php endpoints when in JWT mode (`_ks.authMode === 'jwt'`), mirroring how login already works appid-less:
+
+- request reset → `POST /jwt/password-reset` (no-reveal UX unchanged: same message whether or not the email exists)
+- token check on password.html → `POST /jwt/password-validate` (invalid/expired → redirect to `/`, as before)
+- set new password → `POST /jwt/password-update` (server also revokes every refresh-token session for the user)
+
+HMAC mode keeps the existing `KytePasswordReset` model-CRUD calls untouched. **Requires kyte-php v4.11.0+** for the `/jwt/password-*` endpoints.
+
 ## 2.2.0
 
 ### Improvement: show the file path under the name in the IDE explorer

--- a/assets/js/source/password.js
+++ b/assets/js/source/password.js
@@ -9,11 +9,30 @@ document.addEventListener('KyteInitialized', function(e) {
     }
 
     // get user info from token
-    _ks.get('KytePasswordReset', 'token', token, [], function(response) {
-        if (response.data.length < 1) { location.href = "/"; }
-        email = response.data[0].email;
-        $("#email").val(email);
-    });
+    if (_ks.authMode === 'jwt') {
+        // Shipyard is platform-level (no applicationId), so the anonymous
+        // model-CRUD path can't carry this in JWT mode — use the dedicated
+        // endpoint (kyte-php v4.11.0+, KYTE-#268).
+        $.ajax({
+            method: 'POST',
+            url: _ks.url + '/jwt/password-validate',
+            contentType: 'application/json',
+            dataType: 'json',
+            data: JSON.stringify({ token: token }),
+            success: function(response) {
+                if (!response.valid) { location.href = "/"; return; }
+                email = response.email;
+                $("#email").val(email);
+            },
+            error: function() { location.href = "/"; }
+        });
+    } else {
+        _ks.get('KytePasswordReset', 'token', token, [], function(response) {
+            if (response.data.length < 1) { location.href = "/"; }
+            email = response.data[0].email;
+            $("#email").val(email);
+        });
+    }
 
     // 
     // Password validation and requirements
@@ -165,7 +184,7 @@ document.addEventListener('KyteInitialized', function(e) {
         submitButton.innerHTML = '<i class="fas fa-spinner fa-spin"></i> Updating Password...';
         submitButton.disabled = true;
 
-        _ks.put('KytePasswordReset', 'email', encodeURIComponent(email), {'token':token, 'password':$("#password").val()}, null, [], function(response) {
+        const onUpdated = function() {
             submitButton.innerHTML = originalText;
             // Show success message
             successMsg.classList.remove('d-none');
@@ -173,11 +192,31 @@ document.addEventListener('KyteInitialized', function(e) {
             setTimeout(() => {
                 window.location.href = '/';
             }, 2000);
-        }, function(e) {
+        };
+        const onUpdateFailed = function(e) {
             submitButton.innerHTML = originalText;
             showError(e);
             submitButton.disabled = false;
-        });
+        };
+
+        if (_ks.authMode === 'jwt') {
+            $.ajax({
+                method: 'POST',
+                url: _ks.url + '/jwt/password-update',
+                contentType: 'application/json',
+                dataType: 'json',
+                data: JSON.stringify({ token: token, password: $("#password").val() }),
+                success: onUpdated,
+                error: function(xhr) {
+                    var msg = (xhr.responseJSON && xhr.responseJSON.message)
+                        ? xhr.responseJSON.message
+                        : 'Unable to update password. Please request a new reset link.';
+                    onUpdateFailed(msg);
+                }
+            });
+        } else {
+            _ks.put('KytePasswordReset', 'email', encodeURIComponent(email), {'token':token, 'password':$("#password").val()}, null, [], onUpdated, onUpdateFailed);
+        }
     });
 
     // Initialize email field (would typically come from URL parameter)

--- a/assets/js/source/password.js
+++ b/assets/js/source/password.js
@@ -153,7 +153,7 @@ document.addEventListener('KyteInitialized', function(e) {
         const input = document.getElementById(inputId);
         const button = input.nextElementSibling;
         const icon = button.querySelector('i');
-        
+
         if (input.type === 'password') {
             input.type = 'text';
             icon.className = 'fas fa-eye-slash';
@@ -162,6 +162,10 @@ document.addEventListener('KyteInitialized', function(e) {
             icon.className = 'fas fa-eye';
         }
     }
+    // password.html wires the eye icons via inline onclick="togglePassword(...)",
+    // which needs a global — this function was scoped to the KyteInitialized
+    // listener and threw ReferenceError on every click.
+    window.togglePassword = togglePassword;
 
     // Event listeners
     document.getElementById('password').addEventListener('input', updateRequirements);
@@ -229,6 +233,11 @@ document.addEventListener('KyteInitialized', function(e) {
     });
 
     function showError(message) {
+        // The HMAC error callback hands over an object ({error, message}) —
+        // rendering that directly shows "[object Object]". Extract a string.
+        if (message && typeof message === 'object') {
+            message = message.message || message.error || 'Unable to update password. Please request a new reset link.';
+        }
         const errorMsg = document.getElementById('errorMsg');
         errorMsg.querySelector('span').textContent = message;
         errorMsg.classList.remove('d-none');

--- a/assets/js/source/reset.js
+++ b/assets/js/source/reset.js
@@ -26,18 +26,30 @@ document.addEventListener('KyteInitialized', function(e) {
         submitButton.disabled = true;
         
         if ($("input[type=email]").val()) {
-            _ks.post("KytePasswordReset", {'email' : $("input[type=email]").val()}, null, [], function() {
-                // alert("If the email you provided is correct, an email with reset instructions was sent to you.");
+            // No-reveal in both modes: success and failure show the same
+            // "if the email is correct..." message.
+            const done = function() {
                 submitButton.innerHTML = originalText;
                 submitButton.disabled = false;
                 successMsg.classList.remove('d-none');
-            }, function() {
-                // alert("If the email you provided is correct, an email with reset instructions was sent to you.");
-                submitButton.innerHTML = originalText;
-                submitButton.disabled = false;
-                // showError("If the email you provided is correct, an email with reset instructions was sent to you.")
-                successMsg.classList.remove('d-none');
-            });
+            };
+
+            if (_ks.authMode === 'jwt') {
+                // Shipyard is platform-level (no applicationId), so the
+                // anonymous model-CRUD path can't carry this in JWT mode —
+                // use the dedicated endpoint (kyte-php v4.11.0+, KYTE-#268).
+                $.ajax({
+                    method: 'POST',
+                    url: _ks.url + '/jwt/password-reset',
+                    contentType: 'application/json',
+                    dataType: 'json',
+                    data: JSON.stringify({ email: $("input[type=email]").val() }),
+                    success: done,
+                    error: done
+                });
+            } else {
+                _ks.post("KytePasswordReset", {'email' : $("input[type=email]").val()}, null, [], done, done);
+            }
         }
     });
             


### PR DESCRIPTION
Client half of KYTE-#268 (server half: kyte-php PR #102, the /jwt/password-* endpoints in v4.11.0).

Shipyard is **platform-level** (no `applicationId` → no `x-kyte-appid`), so in JWT mode its anonymous password-reset calls could ride neither HMAC anonymous nor `AppContextStrategy` — the flow failed closed client-side before ever reaching the server. This breaks password reset for active users on any JWT-mode Shipyard install.

`reset.js` / `password.js` now branch on `_ks.authMode === 'jwt'` and call the dedicated endpoints (mirroring how `/jwt/login` already works appid-less):
- request reset → `POST /jwt/password-reset` — no-reveal UX unchanged (same message either way)
- token check on password.html → `POST /jwt/password-validate` — invalid/expired redirects to `/` as before
- set new password → `POST /jwt/password-update` — server also revokes all the user's refresh-token sessions

HMAC mode keeps the existing `KytePasswordReset` model-CRUD calls untouched. **Requires kyte-php v4.11.0+.** `npm run build` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)