### PR TITLE
chore: bump KS_VERSION to 2.3.0 for release

### DIFF
--- a/assets/js/source/kyte-shipyard.js
+++ b/assets/js/source/kyte-shipyard.js
@@ -1,4 +1,4 @@
-var KS_VERSION = '2.2.0';
+var KS_VERSION = '2.3.0';
 
 function loadScript(url, callback) {
     var script = document.createElement('script');


### PR DESCRIPTION
PR #43 added the 2.3.0 CHANGELOG entry but missed the `KS_VERSION` bump in `assets/js/source/kyte-shipyard.js` (still `2.2.0`). The deploy workflow's guard requires it to match the tag, so tagging 2.3.0 without this would fail. Bumps it to `2.3.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)